### PR TITLE
feat: Set noetic the "latest" image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           echo ::set-output name=digest::$(docker inspect --format='{{index .RepoDigests 0}}' $DOCKER_USERNAME/$DOCKER_IMAGENAME:$DOCKER_TAGNAME-$TIMESTAMP)
 
       - name: Publish docker image as latest
-        if: contains(matrix.ros-distro, 'melodic') == true
+        if: contains(matrix.ros-distro, 'noetic') == true
         env:
           DOCKER_TAGNAME: ${{ matrix.ros-distro }}
         run: |


### PR DESCRIPTION
Noetic is the recommended version. Also it seems to be enough stable.
<img width="896" alt="スクリーンショット 2021-01-02 1 39 29" src="https://user-images.githubusercontent.com/3256629/103442651-88946300-4c9b-11eb-857e-baae4b37d3e2.png">
