### PR TITLE
feat: Drop ROS Kinetic support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros-distro: [kinetic, melodic, melodic-arm64, noetic]
+        ros-distro: [melodic, melodic-arm64, noetic]
         experimental: [false]
         include:
           - ros-distro: noetic-testing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ros-distro: [kinetic, melodic, melodic-arm64, noetic, noetic-testing]
+        ros-distro: [melodic, melodic-arm64, noetic, noetic-testing]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# docker_ros-desktop-vnc
+# docker-ros-desktop-vnc
 
 ![Docker Automated build](https://img.shields.io/docker/automated/tiryoh/ros-desktop-vnc)
-[![Publish to Registry](https://github.com/Tiryoh/docker_ros-desktop-vnc/workflows/Publish%20to%20Registry/badge.svg?branch=master)](https://github.com/Tiryoh/docker_ros-desktop-vnc/actions?query=workflow%3A%22Publish+to+Registry%22+branch%3Amaster)
+[![Publish to Registry](https://github.com/Tiryoh/docker_ros-desktop-vnc/workflows/Publish%20to%20Registry/badge.svg?branch=master)](https://github.com/Tiryoh/docker-ros-desktop-vnc/actions?query=workflow%3A%22Publish+to+Registry%22+branch%3Amaster)
 [![](https://img.shields.io/docker/pulls/tiryoh/ros-desktop-vnc.svg)](https://hub.docker.com/r/tiryoh/ros-desktop-vnc)
 
 A Docker image to provide HTML5 VNC interface to access Ubuntu LXDE + ROS, based on [dorowu/ubuntu-desktop-lxde-vnc](https://github.com/fcwu/docker-ubuntu-vnc-desktop)
@@ -27,12 +27,12 @@ Browse http://127.0.0.1:6080/.
 
 ## Docker tags
 
-* [`noetic`](https://github.com/Tiryoh/docker_ros-desktop-vnc/blob/master/noetic/Dockerfile)
-* [`melodic`, `latest`](https://github.com/Tiryoh/docker_ros-desktop-vnc/blob/master/melodic/Dockerfile)
-* [`kinetic`](https://github.com/Tiryoh/docker_ros-desktop-vnc/blob/master/kinetic/Dockerfile)
+* [`noetic`, `latest`](https://github.com/Tiryoh/docker-ros-desktop-vnc/blob/master/noetic/Dockerfile)
+* [`melodic`](https://github.com/Tiryoh/docker-ros-desktop-vnc/blob/master/melodic/Dockerfile)
+* ~~[`kinetic`](https://github.com/Tiryoh/docker-ros-desktop-vnc/blob/master/kinetic/Dockerfile)~~ depricated
 
 Docker tags and build logs are listed on this page.  
-https://github.com/Tiryoh/docker_ros-desktop-vnc/wiki
+https://github.com/Tiryoh/docker-ros-desktop-vnc/wiki
 
 ## License
 


### PR DESCRIPTION
ROS Kinetic has been deprecated in April 2021.

<img width="858" alt="スクリーンショット 2021-05-05 0 07 57" src="https://user-images.githubusercontent.com/3256629/117025560-fa59e780-ad35-11eb-81bc-3d0575623648.png">

source: http://wiki.ros.org/Distributions

related: https://ubuntu.com/blog/ros-kinetic-and-ubuntu-16-04-eol-how-to-mitigate-the-impact