### PR TITLE
chore(ci): Use Trivy cache to avoid CI error

### DIFF
--- a/.github/workflows/update-trivy-cache.yaml
+++ b/.github/workflows/update-trivy-cache.yaml
@@ -17,16 +17,28 @@ jobs:
 
       - name: Download and extract the vulnerability DB
         run: |
-          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
-          oras pull ghcr.io/aquasecurity/trivy-db:2 || oras pull ghcr.io/tiryoh/aquasecurity/trivy-db:2
-          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          mkdir -p "$GITHUB_WORKSPACE/.cache/trivy/db"
+          if ! (oras pull ghcr.io/aquasecurity/trivy-db:2 || oras pull ghcr.io/tiryoh/aquasecurity/trivy-db:2); then
+            echo "Failed to pull database" >&2
+            exit 1
+          fi
+          if ! tar -xzf db.tar.gz -C "$GITHUB_WORKSPACE/.cache/trivy/db"; then
+            echo "Failed to extract database" >&2
+            exit 1
+          fi
           rm db.tar.gz
 
       - name: Download and extract the Java DB
         run: |
-          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
-          oras pull ghcr.io/aquasecurity/trivy-java-db:1 || oras pull ghcr.io/tiryoh/aquasecurity/trivy-java-db:1
-          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          mkdir -p "$GITHUB_WORKSPACE/.cache/trivy/java-db"
+          if ! (oras pull ghcr.io/aquasecurity/trivy-java-db:1 || oras pull ghcr.io/tiryoh/aquasecurity/trivy-java-db:1); then
+            echo "Failed to pull Java database" >&2
+            exit 1
+          fi
+          if ! tar -xzf javadb.tar.gz -C "$GITHUB_WORKSPACE/.cache/trivy/java-db"; then
+            echo "Failed to extract Java database" >&2
+            exit 1
+          fi
           rm javadb.tar.gz
 
       - name: Cache DBs

--- a/.github/workflows/update-trivy-cache.yaml
+++ b/.github/workflows/update-trivy-cache.yaml
@@ -1,0 +1,36 @@
+# Note: This workflow only updates the cache. You should create a separate workflow for your actual Trivy scans.
+# In your scan workflow, set TRIVY_SKIP_DB_UPDATE=true and TRIVY_SKIP_JAVA_DB_UPDATE=true.
+name: Update Trivy Cache
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2 || oras pull ghcr.io/tiryoh/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1 || oras pull ghcr.io/tiryoh/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION
- https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow to update the Trivy vulnerability database cache automatically on a daily schedule.
- **Chores**
	- Added functionality for manual initiation of the cache update process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->