### PR TITLE
docs: Use ghcr.io instead of docker.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run the docker container and access with port `6080`.
 Change the `shm-size` value depending on the situation.
 
 ```
-docker run -p 6080:80 --shm-size=512m tiryoh/ros-desktop-vnc:melodic
+docker run -p 6080:80 --shm-size=512m ghcr.io/tiryoh/ros-desktop-vnc:noetic
 ```
 
 Browse http://127.0.0.1:6080/.
@@ -59,7 +59,7 @@ Stop the container and re-pull the image.
 Example command:
 
 ```
-docker pull tiryoh/ros-desktop-vnc:melodic
+docker pull ghcr.io/tiryoh/ros-desktop-vnc:melodic
 ```
 
 #### 2. Update the key (temporary fix)


### PR DESCRIPTION
https://github.com/Tiryoh/docker-ros2-desktop-vnc/pull/205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Docker instructions with revised commands that now point to a new container image registry, ensuring users access the most current container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->